### PR TITLE
[WIP] Proper expressions

### DIFF
--- a/src/Expr.ml
+++ b/src/Expr.ml
@@ -1,0 +1,167 @@
+(*
+  copyright (c) 2014-2018, Guillaume Bury, Simon Cruanes
+  *)
+
+module type COEF = Expr_intf.COEF
+
+module type VAR = Expr_intf.VAR
+module type FRESH = Expr_intf.FRESH
+module type VAR_GEN = Expr_intf.VAR_GEN
+
+module Linear = struct
+
+  module type S = Expr_intf.Linear
+
+  module Make(C : COEF)(Var : VAR) = struct
+
+    module C = C
+    module Var = Var
+    module Var_map = CCMap.Make(Var)
+
+    type var = Var.t
+    type subst = C.t Var_map.t
+
+    (** Linear combination of variables. *)
+    module Comb = struct
+
+      (* A map from variables to their coefficient in the linear combination. *)
+      type t = C.t Var_map.t
+
+      let compare = Var_map.compare C.compare
+
+      let empty = Var_map.empty
+
+      let is_empty = Var_map.is_empty
+
+      let normalize =
+        Var_map.filter (fun _ c -> not C.(equal c zero))
+
+      let monomial c x =
+        if C.compare c C.zero <> 0 then Var_map.singleton x c else empty
+
+      let monomial1 x = Var_map.singleton x C.one
+
+      let add c x e =
+        let c' = Var_map.get_or ~default:C.zero x e in
+        let c' = C.(c + c') in
+        if C.equal C.zero c' then Var_map.remove x e else Var_map.add x c' e
+
+      let[@inline] map2 ~f a b =
+        Var_map.merge_safe
+          ~f:(fun _ rhs -> match rhs with
+              | `Left x | `Right x -> Some x
+              | `Both (x,y) -> f x y)
+          a b
+
+      let[@inline] some_if_nzero x =
+        if C.equal C.zero x then None else Some x
+
+      let filter_map ~f m =
+        Var_map.fold
+          (fun x y m -> match f y with
+             | None -> m
+             | Some z -> Var_map.add x z m)
+          m Var_map.empty
+
+      module Infix = struct
+        let (+) = map2 ~f:(fun a b -> some_if_nzero C.(a + b))
+        let (-) = map2 ~f:(fun a b -> some_if_nzero C.(a - b))
+        let ( * ) q = filter_map ~f:(fun x -> some_if_nzero C.(x * q))
+      end
+
+      include Infix
+
+      let of_list l = List.fold_left (fun e (c,x) -> add c x e) empty l
+      let to_list e = Var_map.bindings e |> List.rev_map CCPair.swap
+
+      let pp_pair =
+        CCFormat.(pair ~sep:(return "@ * ") C.pp Var.pp)
+
+      let pp out (e:t) =
+        CCFormat.(hovbox @@ list ~sep:(return "@ + ") pp_pair) out (to_list e)
+
+      let eval (subst : subst) (e:t) : C.t =
+        Var_map.fold (fun x c acc ->
+            C.(acc + c * (Var_map.find x subst)))
+          e C.zero
+    end
+
+    module Expr = struct
+
+      type t = {
+        const : C.t;
+        comb : Comb.t
+      }
+
+      let compare e e' =
+        CCOrd.(C.compare e.const e'.const
+               <?> (Comb.compare, e.comb, e'.comb))
+
+      let pp fmt e =
+        Format.fprintf fmt "@[<hov>%a@ + %a" Comb.pp e.comb C.pp e.const
+
+      let mk comb const = { comb; const; }
+
+      let const = mk Comb.empty
+      let zero = const C.zero
+
+      let map2 f g e e' = mk (f e.comb e'.comb) (g e.const e'.const)
+
+      module Infix = struct
+        let (+) = map2 Comb.(+) C.(+)
+        let (-) = map2 Comb.(-) C.(-)
+        let ( * ) c e = mk Comb.(c * e.comb) C.(c * e.const)
+      end
+      include Infix
+
+      let eval subst e = C.(e.const + Comb.eval subst e.comb)
+
+    end
+
+    module Constr = struct
+
+      type op = [ `Leq | `Geq | `Lt | `Gt | `Eq ]
+
+      (** Constraints are expressions implicitly compared to zero. *)
+      type +'a t = {
+        expr: Expr.t;
+        op: 'a;
+      } constraint 'a = [< op ]
+
+      let compare c c' =
+        CCOrd.(compare c.op c'.op
+               <?> (Expr.compare, c.expr, c'.expr))
+
+      let pp_op out o =
+        CCFormat.string out (match o with
+            | `Leq -> "=<" | `Geq -> ">=" | `Lt -> "<" | `Gt -> ">" | `Eq -> "=")
+
+      let pp out c =
+        Format.fprintf out "(@[%a@ %a 0@])"
+          Expr.pp c.expr pp_op c.op
+
+      let op t = t.op
+      let expr t = t.expr
+
+      let mk expr op = { expr; op; }
+
+      let make comb op const =
+        mk (Expr.mk comb (C.neg const)) op
+
+      let split { expr = Expr.{const; comb; } ; op; } =
+        comb, op, C.neg const
+
+      let eval subst c =
+        let v = Expr.eval subst c.expr in
+        begin match c.op with
+          | `Leq -> C.compare v C.zero <= 0
+          | `Geq -> C.compare v C.zero >= 0
+          | `Lt -> C.compare v C.zero < 0
+          | `Gt -> C.compare v C.zero > 0
+          | `Eq -> C.compare v C.zero = 0
+        end
+    end
+
+  end
+
+end

--- a/src/Expr.mli
+++ b/src/Expr.mli
@@ -1,0 +1,18 @@
+
+(** Arithmetic expressions *)
+
+module type COEF = Expr_intf.COEF
+
+module type VAR = Expr_intf.VAR
+module type FRESH = Expr_intf.FRESH
+module type VAR_GEN = Expr_intf.VAR_GEN
+
+module Linear : sig
+
+  module type S = Expr_intf.Linear
+
+  module Make(C : COEF)(Var : VAR)
+    : S with module C = C
+         and module Var = Var
+
+end

--- a/src/Expr_intf.ml
+++ b/src/Expr_intf.ml
@@ -1,0 +1,273 @@
+
+(** {2 Coeficient interface} *)
+
+(** Coeficients
+
+    Coefficients are used in expressions. They usually
+    are either rationals, or integers.
+*)
+module type COEF = sig
+
+  type t
+
+  val equal : t -> t -> bool
+  (** Equality on coefficients. *)
+
+  val compare : t -> t -> int
+  (** Comparison on coefficients. *)
+
+  val pp : t CCFormat.printer
+  (** Pinter for coefficients. *)
+
+  val zero : t
+  (** The zero coefficient. *)
+
+  val one : t
+  (** The one coefficient (to rule them all, :p). *)
+
+  val neg : t -> t
+  (** Unary negation *)
+
+  val (+) : t -> t -> t
+  val (-) : t -> t -> t
+  val ( * ) : t -> t -> t
+  (** Standard operations on coefficients. *)
+
+end
+
+(** {2 Variable interfaces} *)
+
+(** Variable interface.
+
+    Standard interface for variables that are meant to be used
+    in expressions.
+*)
+module type VAR = sig
+  type t
+  (** Variable type. *)
+  val compare : t -> t -> int
+  (** Standard comparison function on variables. *)
+  val pp : t CCFormat.printer
+  (** Printer for variables. *)
+end
+
+(** Fresh variables
+
+    Standard interface for variables with an infinite number
+    of 'fresh' variables. A 'fresh' variable should be distinct
+    from any other.
+*)
+module type FRESH = sig
+
+  type var
+  (** The type of variables. *)
+
+  type t
+  (** A type of state for creating fresh variables. *)
+
+  val create : unit -> t
+  (** Create a fresh variable. *)
+
+  val fresh : t -> var
+  (** Create a fresh variable using an existing variable as base.
+      TODO: need some explaining, about the difference with {!create}. *)
+
+end
+
+(** Generative Variable interface.
+
+    Standard interface for variables that are meant to be used
+    in expressions. Furthermore, fresh variables can be generated
+    (which is useful to refactor and/or put problems in specific
+    formats used by algorithms).
+*)
+module type VAR_GEN = sig
+
+  include VAR
+
+  (** Generate fresh variables on demand *)
+  module Fresh : FRESH with type var := t
+
+end
+
+
+(** {2 Linear expressions & formulas} *)
+
+(** Linear expressions & formulas.
+
+    This modules defines linear expressions (which are linear
+    combinations of variables), and linear constraints, where
+    the value of a linear expressions is constrained.
+*)
+module type Linear = sig
+
+  module C : COEF
+  (** Coeficients used. Can be integers as well as rationals. *)
+
+  module Var : VAR
+  (** Variables used in expressions. *)
+
+  type var = Var.t
+  (** The type of variables appearing in expressions. *)
+
+  module Var_map : CCMap.S with type key = var
+  (** Maps from variables, used for expressions as well as substitutions. *)
+
+  type subst = C.t Var_map.t
+  (** Type for substitutions. *)
+
+  (** Combinations.
+
+      This module defines linear combnations as mapping from variables
+      to coefficients. This allows for very fast computations.
+  *)
+  module Comb : sig
+
+    type t = C.t Var_map.t
+    (** The type of linear combinations. Pretty transparent,
+        most invariants are already enforced by the {!Var_map} module.
+        TODO: make it private to enforce normalization ?
+    *)
+
+    val compare : t -> t -> int
+    (** Comparisons on linear combinations. *)
+
+    val pp : t CCFormat.printer
+    (** Printer for linear combinations. *)
+
+    val is_empty : t -> bool
+    (** Is the given expression empty ?*)
+
+    val normalize : t -> t
+    (** Normalizes the combinations (i.e removes all zero coefficients).
+        TODO: remove this function and make the type private ? *)
+
+    (** {5 Creation} *)
+
+    val empty : t
+    (** The empty linear combination. *)
+
+    val monomial : C.t -> var -> t
+    (** [monome n v] creates the linear combination [n * v] *)
+
+    val monomial1 : var -> t
+    (** [monome1 v] creates the linear combination [1 * v] *)
+
+    val add : C.t -> var -> t -> t
+    (** [add n v t] adds the monome [n * v] to the combination [t]. *)
+
+    (** Infix operations on combinations
+
+        This module defines usual operations on linear combinations,
+        as infix operators to ease reading of complex computations. *)
+    module Infix : sig
+      val (+) : t -> t -> t
+      (** Addition between combinations. *)
+      val (-) : t -> t -> t
+      (** Substraction between combinations. *)
+      val ( * ) : C.t -> t -> t
+      (** Multiplication by a constant. *)
+    end
+    include module type of Infix
+    (** Include the previous module. *)
+
+    val of_list : (C.t * var) list -> t
+    val to_list : t -> (C.t * var) list
+    (** Converters to and from lists of monomes. *)
+
+
+    (** {5 Semantics} *)
+
+    val eval : subst -> t -> C.t
+    (** Evaluate a linear combination given a substitution for its variables.
+        TODO: document potential exceptions raised ?*)
+
+  end
+
+
+  (** Linear expressions.
+
+      Linear expressions represent linear arithmetic expressions as
+      a linear combination and a constant.
+  *)
+  module Expr : sig
+
+    type t
+    (** The type of linear expressions. *)
+
+    val compare : t -> t -> int
+    (** Standard comparison function on expressions. *)
+
+    val pp : t CCFormat.printer
+    (** Standard printing function on expressions. *)
+
+    val zero : t
+    (** The expression [0]. *)
+
+    val const : C.t -> t
+    (** The constant expression. *)
+
+    val mk : Comb.t -> C.t -> t
+    (** [mk c n] makes the linear expression [c + n]. *)
+
+    (** Infix operations on expressions
+
+        This module defines usual operations on linear expressions,
+        as infix operators to ease reading of complex computations. *)
+    module Infix : sig
+      val (+) : t -> t -> t
+      (** Addition between expressions. *)
+      val (-) : t -> t -> t
+      (** Substraction between expressions. *)
+      val ( * ) : C.t -> t -> t
+      (** Multiplication by a constant. *)
+    end
+    include module type of Infix
+    (** Include the previous module. *)
+
+    (** {5 Semantics} *)
+
+    val eval : subst -> t -> C.t
+    (** Evaluate a linear expression given a substitution for its variables.
+        TODO: document potential exceptions raised ?*)
+
+  end
+
+  (** Linear constraints.
+
+      Linear constraints represent constraints on expressions.
+  *)
+  module Constr : sig
+
+    type op = [ `Leq | `Geq | `Lt | `Gt | `Eq ]
+    (** Arithmetic comparison operators. *)
+
+    type +'a t = {
+      expr: Expr.t;
+      op: 'a;
+    } constraint 'a = [< op ]
+    (** Linear constraints. Expressions are implictly comapred to zero. *)
+
+    val compare : 'a t -> 'a t -> int
+    (** Standard comparison function. *)
+
+    val pp : _ t CCFormat.printer
+    (** Standard printing function. *)
+
+    val mk : Expr.t -> 'a -> 'a t
+    val make : Comb.t -> 'a -> C.t -> 'a t
+    (** Create a constraint from a linear expression/combination and a constant. *)
+
+    val op : 'a t -> 'a
+    val expr : _ t -> Expr.t
+    (** Extract the given part from a constraint. *)
+
+    val split : 'a t -> Comb.t * 'a * C.t
+    (** Split the linear combinations from the constant *)
+
+    val eval : subst -> _ t -> bool
+    (** Evaluate the given constraint under a substitution.
+        TODO: document exceptions raised. *)
+  end
+end
+

--- a/src/Rat.ml
+++ b/src/Rat.ml
@@ -3,7 +3,7 @@
 
 (** This abstracts over a type and operation for rationals.
 
-    A possible implementation is Zarith, with module {!Z} *)
+    A possible implementation is Zarith, with module {!Q} *)
 
 module type S = Rat_intf.S
 

--- a/src/Simplex.mli
+++ b/src/Simplex.mli
@@ -1,20 +1,17 @@
 
 (** Solving Linear systems of rational equations. *)
 
-
-module type VAR = Simplex_intf.VAR
-module type VAR_GEN = Simplex_intf.VAR_GEN
+module type VAR = Expr_intf.VAR
+module type FRESH = Expr_intf.FRESH
 
 module type S = Simplex_intf.S
 module type S_FULL = Simplex_intf.S_FULL
 
 (** Low level simplex interface *)
-module Make(Q : Rat.S)(V : VAR) : S with module Q = Q and type var = V.t
+module Make(Q : Rat.S)(V : VAR) :
+  S with module Q = Q and type var = V.t
 
-(** Full version of the simplex, with a high level API *)
-module Make_full(Q : Rat.S)(V : VAR_GEN)
-  : S_FULL
-    with type var = V.t
-     and module Q = Q
-
-
+(** High-level simplex interface *)
+module Make_full(Q : Rat.S)(F : FRESH)
+    (L: Expr.Linear.S with type C.t = Q.t and type Var.t = F.var) :
+  S_FULL with module Q = Q and type var = F.var and module L = L

--- a/src/zarith/Simplex_zarith.mli
+++ b/src/zarith/Simplex_zarith.mli
@@ -1,5 +1,9 @@
 
 open Funarith
 
-module Make(V : Simplex.VAR) : Simplex.S with type Q.t = Q.t and type var = V.t
-module Make_full(V : Simplex.VAR_GEN) : Simplex.S_FULL with type Q.t = Q.t and type var = V.t
+module Make(V : Simplex.VAR)
+  : Simplex.S with type Q.t = Q.t and type var = V.t
+
+module Make_full(F : Simplex.FRESH)
+    (L: Expr.Linear.S with type C.t = Q.t and type Var.t = F.var)
+  : Simplex.S_FULL with type Q.t = Q.t and type var = F.var and module L = L


### PR DESCRIPTION
This is Work in Progress. This PR is mainly there to open discussion about the design.

# Goal
The goal is to have expressions not tied to a specific algorithm. Indeed, arithmetic expressions, and particularly linear expressions, are pretty straight-forward to represent, and it seems a bit of a waste to have a different representation for each algorithm.

# Implementation
Most of the implementation has been extracted from the one that was in the `Simplex` module, wiht a few notable changes:
- renamed expressions to linear combinations (i.e degree 1 polynomials with no constant term)
- introduced linear expressions (i.e. exactly the polynomials of degree 1)
- changed the constraint type to use expressions instead of linear combinations, and make it polymorphic in the comparison operators used.

The `Simplex.Make_full` functor was replaced to take as argument the linear expression module.

# Current status
The `Expr` module compile, as well as the `Simplex` module. However, some changes are still needed to:
- [ ] Adapt the `qcheck` generators to the new representation
- [ ] Adapt the `Diophantine` module to use these expressions (and provide a high-level API similar to the one given for the simplex).
- [ ] Add more operators for the constraints (such as divisibility, etc...)